### PR TITLE
Don't close PHP tags on a non-template file

### DIFF
--- a/govintranet/functions.php
+++ b/govintranet/functions.php
@@ -9528,4 +9528,3 @@ function ht_add_comment_form_top($comment){
 add_filter('comment_form_top', 'ht_add_comment_form_top', 10, 3);
 
 
-?>


### PR DESCRIPTION
Any file that gets loaded before headers are written should not end with a PHP closing tag, because it risks whitespace getting written to the output.
