### PR TITLE
Move the CSS import to the top of the file

### DIFF
--- a/govintranet/style.css
+++ b/govintranet/style.css
@@ -14,6 +14,8 @@ This theme, like WordPress, is licensed under the GPL.
 Use it to make something cool, have fun, and share what you've learned with others.
 */
 
+@import "css/custom.css";
+
 
 /* TYPOGRAPHY */
 
@@ -1265,4 +1267,3 @@ body { left: 5px; }
 	
 }
 
-@import "css/custom.css";


### PR DESCRIPTION
CSS imports can be temperamental about where they're placed. This change simply moves the import to the top of the file to make it work in more browsers.
