### PR TITLE
Fix search autocomplete special chars encoding

### DIFF
--- a/plugins/ht-search-autocomplete/searchautocomplete.php
+++ b/plugins/ht-search-autocomplete/searchautocomplete.php
@@ -207,6 +207,11 @@ class SearchAutocomplete {
 		else {
 			$results = array_merge( $resultsTerms, $resultsPosts );
 		}
+
+		foreach( $results as $index => $result ) {
+			$results[$index]['title'] = html_entity_decode( $result['title'] );
+		}
+
 		$results = apply_filters( 'search_autocomplete_modify_results', $results );
 		echo json_encode( array( 'results' => array_slice( $results, 0, $this->options['autocomplete_numrows'] ) ) );
 		die();


### PR DESCRIPTION
## Why is this change necessary?
- If page or taxonomy title contains special chars they are being
  displayed as encoded entities in the search autocomplete dropdown.
- This is a bug that was fixed in the upsteam "SearchAutocomplete"
  plugin. Fixed partially in 2.1.14, and then correctly in 2.1.15.

<img width="543" alt="screen shot 2016-01-26 at 09 50 13" src="https://cloud.githubusercontent.com/assets/1125251/12578301/de9a585c-c417-11e5-9518-8bce45ae58f8.png">
## How does it address the issue?
- Implements the same fix as released by the "SearchAutocomplete"
  plugin in v2.1.15.
## Notes:
- WordPress support ticket: https://wordpress.org/support/topic/html-characters-and-symbols
- v2.1.14 fix: https://plugins.trac.wordpress.org/changeset/1094900/search-autocomplete/trunk
- v2.1.15 fix: https://plugins.trac.wordpress.org/changeset/1115015/search-autocomplete/trunk
