### PR TITLE
Included filter to remove post-formats query from preview changes link.

### DIFF
--- a/govintranet/functions.php
+++ b/govintranet/functions.php
@@ -84,6 +84,12 @@ function govintranet_setup() {
 	add_post_type_support( 'news', 'post-formats' );
 	add_post_type_support( 'task', 'post-formats' );
 	
+	// This remove this the issue of not being able to preview changes post types which support post-formats
+	function post_format_parameter($url) {
+		$url = remove_query_arg('post_format',$url);
+		return $url;
+	}
+	add_filter('preview_post_link', 'post_format_parameter');
 
 	// Add default posts and comments RSS feed links to head
 	add_theme_support( 'automatic-feed-links' );


### PR DESCRIPTION
When clicking on _preview changes_ on a post-type with post-formats enabled, I'm getting a **404 page**.

I've reading though the posts of the WordPress support forums, it seems like the solution is just add a filter to remove the post-format query from the preview URL.

https://wordpress.org/support/topic/cannot-preview-changes-for-custom-posts#post-6872237

I've included the fix in what I think is an appropriate place in function.php.
