### PR TITLE
Replace custom.css `@import` with header `<link>` tag

### DIFF
--- a/govintranet/header.php
+++ b/govintranet/header.php
@@ -59,6 +59,7 @@ header('X-Frame-Options: SAMEORIGIN');
 	<![endif]-->
 
 	<link rel="stylesheet" type="text/css" media="all" href="<?php bloginfo( 'stylesheet_url' ); ?>" />
+	<link rel="stylesheet" type="text/css" media="all" href="<?php echo get_stylesheet_directory_uri(); ?>/css/custom.css" />
 	<link rel="stylesheet" type="text/css" media="print" href="<?php echo get_stylesheet_directory_uri(); ?>/print.css" />
 
 	<!-- [if lte IE 8]>

--- a/govintranet/style.css
+++ b/govintranet/style.css
@@ -1267,5 +1267,3 @@ body { left: 5px; }
 .page-template-page-left-nav-wide-php .grid-item { width: 100% !important;	}
 	
 }
-
-@import "css/custom.css";


### PR DESCRIPTION
**Because:**
- `custom.css` is an overrides file so you do want to load it in after
  `style.css` to avoid having to make CSS selectors more specific.
- `@import` is temperamental, less reliable, and less performant than
  `<link>`, ref: http://www.stevesouders.com/blog/2009/04/09/dont-use-import/

**This change:**
- Replaces the `@import` at the bottom of `style.css` with a `<link>`
  tag in `header.php` immediately after `style.css` is included.
- This will have the exact same behaviour in terms of load order, but
  is more reliable than the `@import`.
