### PR TITLE
Fix search form button alignment

### DIFF
--- a/govintranet/style.css
+++ b/govintranet/style.css
@@ -309,7 +309,7 @@ a.btn.filter_results { width: 100%; text-decoration: none; overflow:hidden; }
 	font-size: 16px;
 }
 #searchformdiv .btn {
-	font-size: 16px;
+	font-size: 14px;
 	border-radius: 0 3px 3px 0;
 }
 #sbc-search label {


### PR DESCRIPTION
**Because:**
- The button on the header form is slightly mis-aligned.

**This change:**
- Sets the `#searchformdiv .btn` font size to 14px in order to resolve the alignment
  issue.

**Old:**

![image](https://cloud.githubusercontent.com/assets/1125251/13610201/70bdefb6-e554-11e5-9951-ff46e8b4e03e.png)

**New:**

![image](https://cloud.githubusercontent.com/assets/1125251/13610208/74b34bde-e554-11e5-8f88-4b0b4029ea3f.png)
