### PR TITLE
Replace `.alert`s with `.well`s within content

### DIFF
--- a/govintranet/part-downloads.php
+++ b/govintranet/part-downloads.php
@@ -2,7 +2,7 @@
 global $post;
 $current_attachments = get_field('document_attachments');
 if ($current_attachments){
-	echo "<div class='alert alert-info'>";
+	echo "<div class='well'>";
 	echo "<h3>" . _x('Downloads' , 'Documents to download' , 'govintranet') . " <span class='dashicons dashicons-download'></span></h3>";
 	foreach ($current_attachments as $ca){
 		$c = $ca['document_attachment'];

--- a/govintranet/single-event.php
+++ b/govintranet/single-event.php
@@ -138,7 +138,7 @@ $mainid=$post->ID;
 				google.maps.event.addDomListener(window, 'load', initialize);
 			</script>
 			<div id="map-canvas" class="google_map"></div>
-			<div class="alert alert-info" id="map-location"><?php echo wpautop($text); ?></div>
+			<div class="well" id="map-location"><?php echo wpautop($text); ?></div>
 		</div>
 	<?php endif; 
 	

--- a/govintranet/single-project.php
+++ b/govintranet/single-project.php
@@ -190,16 +190,7 @@ if ( have_posts() ) while ( have_posts() ) : the_post();
 			<?php
 			the_content(); 
 
-			$current_attachments = get_field('document_attachments');
-			if ($current_attachments){
-				echo "<div class='alert alert-info'>";
-				echo "<h3>" . _x('Downloads' , 'Documents to download' , 'govintranet') . " <span class='dashicons dashicons-download'></span></h3>";
-				foreach ($current_attachments as $ca){
-					$c = $ca['document_attachment'];
-					if ( isset($c['title']) ) echo "<p><a class='alert-link' href='".$c['url']."'>".$c['title']."</a></p>";
-				}
-				echo "</div>";
-			}	
+			get_template_part("part", "downloads");
 
 			if ('open' == $post->comment_status) {
 				 comments_template( '', true ); 

--- a/govintranet/single-task.php
+++ b/govintranet/single-task.php
@@ -172,15 +172,8 @@ get_header(); ?>
 
 			endif;
 
-			if( have_rows('document_attachments') ) : 
-				echo "<div class='alert alert-info'>";
-				echo "<h3>" . _x('Downloads' , 'Documents to download' , 'govintranet') . " <span class='dashicons dashicons-download'></span></h3>";
-				    while ( have_rows('document_attachments') ) : the_row(); 
-						$doc = get_sub_field('document_attachment'); 
-						if ( isset($doc['title']) )  echo "<p><a class='alert-link' href='".$doc['url']."'>".$doc['title']."</a></p>";
-					endwhile;
-				echo "</div>";
-			endif;
+			get_template_part("part", "downloads");
+
 			if ('open' == $post->comment_status) {
 				 comments_template( '', true ); 
 			}


### PR DESCRIPTION
##### Because:
- Bootstrap's alerts are intended to be used as flash messages (like
  the homepage emergency message), not as a box for sections within
  content.
- People may want to style the alerts differently to the bootstrap
  default. Doing so should not change the downloads/attachments or
  event maps styling.
##### This change:
- Replaces uses of the `alert` component within the content with
  Bootstrap's `well` which is better suited to this usage.
- Replaces duplicated code in the project and task single templates
  with the template part used by other post types.
