### PR TITLE
Replace links built with guid for get_permalink()

### DIFF
--- a/govintranet/functions.php
+++ b/govintranet/functions.php
@@ -9643,7 +9643,7 @@ function listdocs_func( $atts ) {
 	$html= '<ul class="docmenu">';
 	global $post;
 	if ( $docs->have_posts() ) while ( $docs->have_posts() ) : $docs->the_post(); 
-		$html.= '<li><a href="'.$post->guid.'">';
+		$html.= '<li><a href="'.get_permalink($post->ID).'">';
 		$html.= ''.$post->post_title;
 		$html.= '</a>';
 		if ($post->post_content && $desc) $html.='<br>'.$post->post_content.'</li>';

--- a/govintranet/search.php
+++ b/govintranet/search.php
@@ -20,7 +20,7 @@ if ($gishelpfulsearch == 1){
 				$location=str_replace('/author', '/staff', $location);
 			} else {
 					if ($_GET['pt'] != 'user') {
-						$location=$post->guid; 
+						$location=get_permalink($post->ID);
 					}
 			}
 		endwhile;

--- a/govintranet/tag.php
+++ b/govintranet/tag.php
@@ -135,7 +135,7 @@ get_header();
 					$image_url = get_the_post_thumbnail($id, 'thumbnail', array('class' => 'alignright'));
 					$ext_icon = '';
 					echo "<div class='media'>" ;
-					$contexturl=$post->guid;
+					$contexturl=get_permalink($post->ID);
 					$context='';
 					$titlecontext='';
 					if ($post_type=='Post_tag') { 


### PR DESCRIPTION
#### Because:
- Although `guid` does contain a URL for the page. [It should never be
  changed](https://codex.wordpress.org/Changing_The_Site_URL#Important_GUID_Note).
- If the `guid` field is used for link destinations and the site's URL
  changes, e.g. example.com -> blog.example.com, or the DB from the
  live site is copied back to a staging site, e.g. www.example.com ->
  staging.example.com. Then any links built with `guid` will continue to point to the original URL.
- [The official setup instructions](http://govintranetters.helpfulclients.com/task/setup-guide-instructions/create-pages/) provide a [Basic page export](http://govintranetters.helpfulclients.com/wp-content/uploads/2013/10/govintranet.wordpress.2015-02-15.xml_.zip). This
  export creates 10 pages with `guid` fields pointing to
  http://giupgrade.helpfulclients.com, so any sites created from this
  base export will link to the helpful domain.
#### This change:
- Replaces all 4 instances where `guid` is used to build links with
  `get_permalink()`, which will always provide the correct URL.
