### PR TITLE
Fix `%htitle` in breadcrumb on staff dir profiles

### DIFF
--- a/govintranet/bbpress/forum.php
+++ b/govintranet/bbpress/forum.php
@@ -13,15 +13,14 @@ if ( have_posts() ) while ( have_posts() ) : the_post(); ?>
 		<div class='breadcrumbs'>
 		<?php 
 		if ( bbp_is_single_user() ):
+			$home = "<a href='" . get_home_url() . "'>" . __(get_bloginfo('name'), 'govintranet') . "</a>";
 			$sd = get_option('options_module_staff_directory_page');
 			$sd = $sd[0];
 			$directory = "<a href='" . get_permalink($sd) . "'>" . get_the_title($sd) . "</a>";
 			if ( function_exists('bcn_display') ){
 				$bcn = get_option('bcn_options');
-				$home = $bcn['Hhome_template'];
 				$sep = $bcn['hseparator'];
 			} else {
-				$home = "<a href='".site_url("/")."'>".__('Home','govintranet')."</a>";
 				$sep = " > ";
 			}
 			echo $home; 


### PR DESCRIPTION
#### Because:

* The staff directory page is displaying `%htitle%` instead of the home
  page as the root item of the breadcrumb.

#### This change:

* Constructs the home breadcrumb item manually, same as the staff
  directory item rather than extracting the template from the
  `bcn_options`.
* Uses the site name from options rather than assuming 'Home', as this
  is consitent with the breadcrumbs created via `bcn_display` elsewhere
  on the site.

Fixes #27