### PR TITLE
Fix news expiry ACF conditional fields

### DIFF
--- a/govintranet/functions.php
+++ b/govintranet/functions.php
@@ -5458,9 +5458,11 @@ if( function_exists('acf_add_local_field_group') ){
 					'required' => 1,
 					'conditional_logic' => array (
 						array (
-							'field' => 'field_536ec2de62b52',
-							'operator' => '==',
-							'value' => '1',
+							array (
+								'field' => 'field_536ec2de62b52',
+								'operator' => '==',
+								'value' => '1',
+							),
 						),
 					),
 					'display_format' => 'd/m/Y',
@@ -5477,9 +5479,11 @@ if( function_exists('acf_add_local_field_group') ){
 					'required' => 1,
 					'conditional_logic' => array (
 						array (
-							'field' => 'field_536ec2de62b52',
-							'operator' => '==',
-							'value' => '1',
+							array (
+								'field' => 'field_536ec2de62b52',
+								'operator' => '==',
+								'value' => '1',
+							),
 						),
 					),
 					'default_value' => '',


### PR DESCRIPTION
#### Because:

* The conditional logic on for the 'News expiry' field group is broken
  with ACF versions >= 5.5.9.
* [4.34.10](https://github.com/helpful/govintranet/commit/89be7feea8a71593dab4f0b41cb6e53c632c0cb7) included a fix for this issue, but that appears not to have
  worked as we're still experiencing this issue in the 4.34.12.1
  (latest).

#### This change:

* Adds a missing level of `array()` nesting to the the
  `'conditional_logic'` field setting.
* This is replicates the structure expored by the ACF UI, and matches
  the `news_expiry_action` field below (which is working correctly).

Fixes #26

Ref: https://help.govintra.net/topic/news-expiry-wont-turn-off/