### PR TITLE
govintranet_before_header action

### DIFF
--- a/govintranet/header.php
+++ b/govintranet/header.php
@@ -31,6 +31,7 @@ header('X-Frame-Options: SAMEORIGIN');
 		wp_title( '', true, 'right' );
 		?>
 	</title>
+	<?php do_action('govintranet_before_header'); ?>
 	<!--Google Analytics-->
 	<?php	
 	// write script for google analytics (only do on homepage if homepage tracking is set or on search page)


### PR DESCRIPTION
Adds an action hook near the start of the header allowing plugins to write to output before the google tracking code.

## Justification

We needed to add variables to Google Tag Manager specific to the current page, specifically its author and date of publication, so that the client could track readership behaviour. This could not be done with the existing google tracking code, which is the same on all pages. It could not be done with later hooks since the `dataLayer` variable needs to be present before calling the tracking code.

[Documentation on the dataLayer variable and Google Tag Manager](https://developers.google.com/tag-manager/devguide).

It would be a much larger proposal to suggest adding Google Tag Manager support to GovIntranet (though it might have value to explore), not least because not everybody prefers Google as their solution. This single action should be harmless and remain flexible.