### PR TITLE
Fix the custom link colour

### DIFF
--- a/govintranet/functions.php
+++ b/govintranet/functions.php
@@ -10861,8 +10861,8 @@ function govintranet_custom_styles() {
 	
 	// write custom css for background header colour
 
-	$bg = get_theme_mod('link_color', '#428bca');
-	$bg = get_theme_mod('link_visited_color', '#7303aa');
+	$link_color = get_theme_mod('link_color', '#428bca');
+	$link_visited_color = get_theme_mod('link_visited_color', '#7303aa');
 	$headtext = get_theme_mod('header_textcolor', '#ffffff'); if ( substr($headtext, 0 , 1 ) != "#") $headtext="#".$headtext;
 	$headimage = get_theme_mod('header_image', '');
 	$custom_logo_id = get_theme_mod( 'custom_logo' );
@@ -10883,9 +10883,9 @@ function govintranet_custom_styles() {
 		 $giscc = $gishex; 
 	endif;
 
-	$custom_css.= "a, a .listglyph  {color: ".$bg.";}";
+	$custom_css.= "a, a .listglyph  {color: ".$link_color.";}";
 	$custom_css.= "a:visited.btn.btn-primary, a:link.btn.btn-primary {color:".$btn_text.";}";
-	$custom_css.= "a:visited, a:visited .listglyph {color: ".$bg.";}";
+	$custom_css.= "a:visited, a:visited .listglyph {color: ".$link_visited_color.";}";
 	if ($headimage != 'remove-header' ):
 		$custom_css.= "#topstrip  {	background: ".$gishex." url(".get_header_image()."); color: ".$headtext.";	}";
 	else:


### PR DESCRIPTION
This change fixes the colour of the links so that they match the options set in the customise admin menu. Currently, links are being displayed using the visited link colour. 

I've noticed this issue in Version: 4.39.4.1 of govintranet using WordPress 4.9.4

The issue may have been introduced here. https://github.com/helpful/govintranet/commit/70ee2fd5b9f446849681a867151c7f9c81da8c26