### PR TITLE
Added Projects to Related Field

### DIFF
--- a/govintranet/functions.php
+++ b/govintranet/functions.php
@@ -5360,6 +5360,7 @@ if( function_exists('acf_add_local_field_group') ){
 						2 => 'event',
 						3 => 'task',
 						4 => 'news',
+						5 => 'project',
 					),
 					'taxonomy' => array (
 					),


### PR DESCRIPTION
I wanted to link a page I was creating to a Project, but it was missing, so I've added a line to enable the related field functionality to now select any related projects